### PR TITLE
Disable forward_fill for criteria in criterion/scores.py

### DIFF
--- a/criterion/scores.py
+++ b/criterion/scores.py
@@ -10,6 +10,7 @@ NUDESC_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "016"
     ),  # $cs-digipod#016 "Nursing Delirium Screening Scale (NU-DESC) score"
     override_value_required=False,
+    forward_fill=False,
 )
 DRS_documented = PointInTimeCriterion(
     category=CohortCategory.INTERVENTION,
@@ -17,6 +18,7 @@ DRS_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "019"
     ),  # $cs-digipod#019 "Delirium Rating Scale score"
     override_value_required=False,
+    forward_fill=False,
 )
 DOS_documented = PointInTimeCriterion(
     category=CohortCategory.INTERVENTION,
@@ -24,6 +26,7 @@ DOS_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "020"
     ),  # $cs-digipod#020 "Delirium Observation Scale score"
     override_value_required=False,
+    forward_fill=False,
 )
 CAM_documented = PointInTimeCriterion(
     category=CohortCategory.INTERVENTION,
@@ -31,6 +34,7 @@ CAM_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "018"
     ),  # $cs-digipod#018 "Confusion Assessment Method score"
     override_value_required=False,
+    forward_fill=False,
 )
 AT4_documented = PointInTimeCriterion(
     category=CohortCategory.INTERVENTION,
@@ -38,6 +42,7 @@ AT4_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "017"
     ),  # $cs-digipod#017 "4AT score"
     override_value_required=False,
+    forward_fill=False,
 )
 TDCAM_documented = PointInTimeCriterion(
     category=CohortCategory.INTERVENTION,
@@ -45,6 +50,7 @@ TDCAM_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "021"
     ),  # $cs-digipod#021 "3-minute Diagnostic Interview for CAM-defined Delirium score"
     override_value_required=False,
+    forward_fill=False,
 )
 
 CAMICU_documented = PointInTimeCriterion(
@@ -53,6 +59,7 @@ CAMICU_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "022"
     ),  # $cs-digipod#022 "Confusion Assessment Method for the Intensive Care Unit score"
     override_value_required=False,
+    forward_fill=False,
 )
 
 DDS_documented = PointInTimeCriterion(
@@ -61,6 +68,7 @@ DDS_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "023"
     ),  # $cs-digipod#023 "Delirium Detection Score score"
     override_value_required=False,
+    forward_fill=False,
 )
 
 ICDSC_documented = PointInTimeCriterion(
@@ -69,4 +77,5 @@ ICDSC_documented = PointInTimeCriterion(
         DigiPOD.system_uri, "024"
     ),  # $cs-digipod#024 "Intensive Care Delirium Screening Checklist score"
     override_value_required=False,
+    forward_fill=False,
 )


### PR DESCRIPTION
The intervention criteria can change over time, including due to the invertion being discontinued after some point in time.
In such cases, forward filling would hide the stop of the intervention.

Depends on https://github.com/CODEX-CELIDA/execution-engine/pull/237.